### PR TITLE
Farming contract notification fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.26'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
@@ -159,7 +159,13 @@ public class TimeTrackingReminderPlugin extends Plugin {
                         itemManager,
                         "Your farming contract is ready.",
                         22993, // Seed pack
-                        () -> config.farmingContract() && showInfoboxInInstance() && farmingContractManager.getSummary() != SummaryState.IN_PROGRESS
+                        () -> {
+                            boolean isInProgress = farmingContractManager.getSummary() == SummaryState.IN_PROGRESS;
+                            boolean isOccupiedWrongSeed = farmingContractManager.getSummary() == SummaryState.OCCUPIED && farmingContractManager.getContractCropState() == null;
+                            boolean farmingContractReady = !isInProgress && !isOccupiedWrongSeed;
+
+                            return config.farmingContract() && showInfoboxInInstance() && farmingContractReady;
+                        }
                 ),
                 new TimeTrackingReminderGroup(
                         this,
@@ -267,7 +273,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
     }
 
     private boolean showInfoboxInInstance() {
-        if (!config.showInInstances() && client.isInInstancedRegion()){
+        if (!config.showInInstances() && client.isInInstancedRegion()) {
             return false;
         }
 


### PR DESCRIPTION
Applies to Issue #21 

When the wrong crop is planted in your contract plot, you cannot take any action because the plant has to finish growing first. With this change it will no longer say the contract is ready until you can take action. I updated the runelite dependency to latest since I needed this for testing.

It shows contract is ready if:
- plot is empty
- correct crop is ready
- wrong crop is planted but is ready

It wont show contract is ready if:
- correct crop is growing
- wrong crop is growing