### PR TITLE
Add mushroom & belladonna patches

### DIFF
--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
@@ -190,4 +190,22 @@ public interface TimeTrackingReminderConfig extends Config {
     default boolean cactusPatches() {
         return true;
     }
+
+	@ConfigItem(
+		keyName = "mushroompatch",
+		name = "Mushroom patch",
+		description = "Show an infobox when your mushroom patch is ready.",
+		section = farmingPatchesSection,
+		position = 211
+	)
+	default boolean mushroomPatch() { return true; }
+
+	@ConfigItem(
+		keyName = "belladonnapatch",
+		name = "Belladonna patch",
+		description = "Show an infobox when your belladonna patch is ready.",
+		section = farmingPatchesSection,
+		position = 212
+	)
+	default boolean belladonnaPatch() { return true; }
 }

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
@@ -229,7 +229,23 @@ public class TimeTrackingReminderPlugin extends Plugin {
                         "Your redwood patch is ready.",
                         19669, // Redwood log
                         () -> config.redwoodPatch() && showInfoboxInInstance() && farmingTracker.getSummary(Tab.REDWOOD) != SummaryState.IN_PROGRESS
-                )
+                ),
+				new TimeTrackingReminderGroup(
+					this,
+					infoBoxManager,
+					itemManager,
+					"Your mushroom patch is ready.",
+					6004, // Mushroom
+					() -> config.mushroomPatch() && showInfoboxInInstance() && farmingTracker.getSummary(Tab.MUSHROOM) != SummaryState.IN_PROGRESS
+				),
+				new TimeTrackingReminderGroup(
+					this,
+					infoBoxManager,
+					itemManager,
+					"Your belladonna patch is ready.",
+					27790, // Nightshade
+					() -> config.belladonnaPatch() && showInfoboxInInstance() && farmingTracker.getSummary(Tab.BELLADONNA) != SummaryState.IN_PROGRESS
+				)
         };
     }
 

--- a/src/main/java/com/timetrackingreminder/runelite/farming/PatchImplementation.java
+++ b/src/main/java/com/timetrackingreminder/runelite/farming/PatchImplementation.java
@@ -34,7 +34,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum PatchImplementation
 {
-	BELLADONNA(Tab.SPECIAL, "", false)
+	BELLADONNA(Tab.BELLADONNA, "", false)
 		{
 			@Override
 			PatchState forVarbitValue(int value)
@@ -72,7 +72,7 @@ public enum PatchImplementation
 				return null;
 			}
 		},
-	MUSHROOM(Tab.SPECIAL, "", false)
+	MUSHROOM(Tab.MUSHROOM, "", false)
 		{
 			@Override
 			PatchState forVarbitValue(int value)

--- a/src/main/java/com/timetrackingreminder/runelite/farming/Tab.java
+++ b/src/main/java/com/timetrackingreminder/runelite/farming/Tab.java
@@ -20,6 +20,8 @@ public enum Tab
 	BUSH("Bush Patches", ItemID.POISON_IVY_BERRIES),
 	GRAPE("Grape Patches", ItemID.GRAPES),
 	SPECIAL("Special Patches", ItemID.MUSHROOM),
+	MUSHROOM("Mushroom Patch", ItemID.MUSHROOM),
+	BELLADONNA("Belladonna Patch", ItemID.NIGHTSHADE),
 	GIANT_COMPOST("Giant Compost Bin", ItemID.ULTRACOMPOST),
 	SEAWEED("Seaweed Patches", ItemID.GIANT_SEAWEED),
 	CALQUAT("Calquat Patch", ItemID.CALQUAT_FRUIT),


### PR DESCRIPTION
I'm not sure if I did this right, but tried anyways. I only tested it with belladonna and noticed that the infobox didn't disappear after harvesting, but did disappear once I replanted. Is that an issue on my end or just how the plugin is supposed to work?