### PR TITLE
Support for crystal tree ready infobox

### DIFF
--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
@@ -212,4 +212,15 @@ public interface TimeTrackingReminderConfig extends Config {
     default boolean belladonnaPatch() {
         return true;
     }
+
+    @ConfigItem(
+            keyName = "crystalpatch",
+            name = "Crystal patch",
+            description = "Show an infobox when your crystal patch is ready.",
+            section = farmingPatchesSection,
+            position = 213
+    )
+    default boolean crystalPatch() {
+        return true;
+    }
 }

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
@@ -245,6 +245,14 @@ public class TimeTrackingReminderPlugin extends Plugin {
                         "Your belladonna patch is ready.",
                         27790, // Nightshade
                         () -> config.belladonnaPatch() && showInfoboxInInstance() && farmingTracker.getSummary(Tab.BELLADONNA) != SummaryState.IN_PROGRESS
+                ),
+                new TimeTrackingReminderGroup(
+                        this,
+                        infoBoxManager,
+                        itemManager,
+                        "Your Crystal patch is ready.",
+                        23962, // Crystal shard
+                        () -> config.crystalPatch() && showInfoboxInInstance() && farmingTracker.getSummary(Tab.CRYSTAL) != SummaryState.IN_PROGRESS
                 )
         };
     }

--- a/src/main/java/com/timetrackingreminder/runelite/farming/PatchImplementation.java
+++ b/src/main/java/com/timetrackingreminder/runelite/farming/PatchImplementation.java
@@ -2577,7 +2577,7 @@ public enum PatchImplementation
 				return null;
 			}
 		},
-	CRYSTAL_TREE(Tab.SPECIAL, "Crystal Tree", true)
+	CRYSTAL_TREE(Tab.CRYSTAL, "Crystal Tree", true)
 		{
 			@Override
 			PatchState forVarbitValue(int value)

--- a/src/main/java/com/timetrackingreminder/runelite/farming/Tab.java
+++ b/src/main/java/com/timetrackingreminder/runelite/farming/Tab.java
@@ -29,9 +29,10 @@ public enum Tab
 	REDWOOD("Redwood Patch", ItemID.REDWOOD_LOGS),
 	CACTUS("Cactus Patches", ItemID.POTATO_CACTUS),
 	HESPORI("Hespori Patch", ItemID.TANGLEROOT),
+	CRYSTAL("Crystal Patch", ItemID.CRYSTAL_SHARD),
 	TIME_OFFSET("Farming Tick Offset", ItemID.WATERING_CAN);
 
-	public static final Tab[] FARMING_TABS = {HERB, TREE, FRUIT_TREE, SPECIAL, FLOWER, ALLOTMENT, BUSH, GRAPE, HOPS};
+	public static final Tab[] FARMING_TABS = {HERB, TREE, FRUIT_TREE, SPECIAL, FLOWER, ALLOTMENT, BUSH, GRAPE, HOPS, CRYSTAL};
 
 	private final String name;
 	private final int itemID;


### PR DESCRIPTION
Took the liberty of adding crystal tree support (as per issues #23/37)
Works well, with my limited testing.

Might want to change the info box icon (I used the same icon as the time tracking plugin)