### PR TITLE
Add support for custom infobox text

### DIFF
--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
@@ -33,6 +33,14 @@ public interface TimeTrackingReminderConfig extends Config {
         return true;
     }
 
+	@ConfigItem(
+		keyName = "customOverlayMessage",
+		name = "Custom Overlay Message",
+		description = "Use a custom overlay message instead of the default 'Ready'",
+		position = 2
+	)
+	default String customMessage() { return "Ready"; }
+
     // -- Miscellaneous infoboxes ---
 
     @ConfigItem(

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderGroup.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderGroup.java
@@ -9,6 +9,7 @@ import java.util.concurrent.Callable;
 
 public class TimeTrackingReminderGroup {
     private final Plugin plugin;
+    private final TimeTrackingReminderConfig config;
     private final InfoBoxManager infoBoxManager;
     private final ItemManager itemManager;
 
@@ -20,6 +21,7 @@ public class TimeTrackingReminderGroup {
 
     TimeTrackingReminderGroup(
             Plugin plugin,
+            TimeTrackingReminderConfig config,
             InfoBoxManager infoBoxManager,
             ItemManager itemManager,
             String tooltip,
@@ -27,6 +29,7 @@ public class TimeTrackingReminderGroup {
             Callable<Boolean> shouldShowInfoBoxCallable
     ) {
         this.plugin = plugin;
+        this.config = config;
         this.infoBoxManager = infoBoxManager;
         this.itemManager = itemManager;
 
@@ -57,7 +60,7 @@ public class TimeTrackingReminderGroup {
         }
 
         final BufferedImage itemImage = itemManager.getImage(itemId);
-        infoBox = new TimeTrackingReminderInfoBox(plugin, itemImage, tooltip);
+        infoBox = new TimeTrackingReminderInfoBox(plugin, config, itemImage, tooltip);
         infoBoxManager.addInfoBox(infoBox);
     }
 

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderInfoBox.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderInfoBox.java
@@ -8,11 +8,13 @@ import net.runelite.client.ui.overlay.infobox.InfoBox;
 
 class TimeTrackingReminderInfoBox extends InfoBox {
     private final Plugin plugin;
+	private final TimeTrackingReminderConfig config;
     private final String tooltip;
 
-    TimeTrackingReminderInfoBox(Plugin plugin, BufferedImage image, String tooltip) {
+    TimeTrackingReminderInfoBox(Plugin plugin, TimeTrackingReminderConfig config, BufferedImage image, String tooltip) {
         super(image, plugin);
         this.plugin = plugin;
+        this.config = config;
         this.tooltip = tooltip;
     }
 
@@ -24,7 +26,7 @@ class TimeTrackingReminderInfoBox extends InfoBox {
 
     @Override
     public String getText() {
-        return "Ready";
+    	return config.customMessage();
     }
 
     @Override

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
@@ -114,6 +114,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
         reminderGroups = new TimeTrackingReminderGroup[]{
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your bird houses are ready.",
@@ -122,6 +123,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your herb patches are ready.",
@@ -130,6 +132,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your tree patches are ready.",
@@ -138,6 +141,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your fruit tree patches are ready.",
@@ -146,6 +150,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your seaweed patches are ready.",
@@ -154,6 +159,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your bush patches are ready.",
@@ -162,6 +168,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your farming contract is ready.",
@@ -176,6 +183,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your Hespori patch is ready.",
@@ -184,6 +192,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your giant compost bin is ready.",
@@ -192,6 +201,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your calquat patch is ready.",
@@ -200,6 +210,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your hardwood patches are ready.",
@@ -208,6 +219,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your hops patches are ready.",
@@ -216,6 +228,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your cactus patches are ready.",
@@ -224,6 +237,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your redwood patch is ready.",
@@ -232,6 +246,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your mushroom patch is ready.",
@@ -240,6 +255,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your belladonna patch is ready.",
@@ -248,6 +264,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 ),
                 new TimeTrackingReminderGroup(
                         this,
+                        config,
                         infoBoxManager,
                         itemManager,
                         "Your Crystal patch is ready.",


### PR DESCRIPTION
Small PR to add the ability to customize the Infobox text for when the group is Ready. 

I would prefer personally to use "R", so thought I'd offer a way for others to customize.

Some examples:

![image](https://github.com/queicherius/runelite-time-tracking-reminder/assets/134161838/44c846b2-9723-4317-87f3-6547365054ae)

![image](https://github.com/queicherius/runelite-time-tracking-reminder/assets/134161838/4a81ea73-5c76-463a-b0e4-42ac1df5dc88)
