### PR TITLE
Added option to ignore patches in the farming guild

### DIFF
--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
@@ -7,6 +7,8 @@ import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup("timetrackingreminder")
 public interface TimeTrackingReminderConfig extends Config {
+    String CONFIG_GROUP = "timetrackingreminder";
+
     @ConfigSection(
             name = "Miscellaneous",
             description = "Settings for miscellaneous infoboxes",
@@ -61,6 +63,16 @@ public interface TimeTrackingReminderConfig extends Config {
     )
     default boolean onlyHarvestable() {
         return false;
+    }
+
+    @ConfigItem(
+            keyName = "ignorefarmingguild",
+            name = "Ignore Farming Guild",
+            description = "Ignore patches in the farming guild when determining what to show.",
+            position = 5
+    )
+    default boolean ignoreFarmingGuild() {
+        return true;
     }
 
     // -- Miscellaneous infoboxes ---

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
@@ -100,6 +100,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 compostTracker,
                 paymentTracker
         );
+        farmingTracker.setIgnoreFarmingGuild(config.ignoreFarmingGuild());
 
         farmingContractManager = new FarmingContractManager(
                 client,
@@ -302,11 +303,13 @@ public class TimeTrackingReminderPlugin extends Plugin {
 
     @Subscribe
     public void onConfigChanged(ConfigChanged event) {
-        if (!event.getGroup().equals(TimeTrackingConfig.CONFIG_GROUP)) {
+        String group = event.getGroup();
+        if (!group.equals(TimeTrackingConfig.CONFIG_GROUP) && !group.equals(TimeTrackingReminderConfig.CONFIG_GROUP)) {
             return;
         }
 
         birdHouseTracker.loadFromConfig();
+        farmingTracker.setIgnoreFarmingGuild(config.ignoreFarmingGuild());
         farmingTracker.loadCompletionTimes();
         farmingContractManager.loadContractFromConfig();
     }

--- a/src/main/java/com/timetrackingreminder/runelite/farming/FarmingTracker.java
+++ b/src/main/java/com/timetrackingreminder/runelite/farming/FarmingTracker.java
@@ -29,22 +29,14 @@ package com.timetrackingreminder.runelite.farming;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.inject.Singleton;
 import java.time.Instant;
-import java.util.Collection;
-import java.util.EnumMap;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.GameState;
-import net.runelite.api.Varbits;
-import net.runelite.api.WidgetNode;
+import net.runelite.api.*;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.widgets.WidgetModalMode;
 import net.runelite.client.Notifier;
@@ -63,6 +55,19 @@ import net.runelite.client.util.Text;
 )
 public class FarmingTracker
 {
+	private final int FARMING_GUILD_REGION_ID = 4922;
+
+	// Categories of patches that exist both within and outside the farming guild, thus effected by the ignore flag
+	private final Set<Tab> FARMING_GUILD_EFFECTED_TABS = new HashSet<Tab>(Arrays.asList(
+			Tab.ALLOTMENT,
+			Tab.FLOWER,
+			Tab.HERB,
+			Tab.TREE,
+			Tab.FRUIT_TREE,
+			Tab.BUSH,
+			Tab.CACTUS
+	));
+
 	private final Client client;
 	private final ItemManager itemManager;
 	private final ConfigManager configManager;
@@ -85,6 +90,9 @@ public class FarmingTracker
 	private boolean newRegionLoaded;
 	private Collection<FarmingRegion> lastRegions;
 	private boolean firstNotifyCheck = true;
+
+	@Setter
+	private boolean ignoreFarmingGuild = false;
 
 	public FarmingTabPanel createTabPanel(Tab tab, FarmingContractManager farmingContractManager)
 	{
@@ -442,6 +450,10 @@ public class FarmingTracker
 
 			for (FarmingPatch patch : tab.getValue())
 			{
+				if (shouldSkipFarmingGuildPatch(tab.getKey(), patch)) {
+					continue;
+				}
+
 				PatchPrediction prediction = predictPatch(patch);
 				if (prediction == null || prediction.getProduce().getItemID() < 0)
 				{
@@ -468,7 +480,7 @@ public class FarmingTracker
 					{
 						isHarvestable = prediction.getStage() == (prediction.getStages() - 1);
 					}
-					else if (prediction.getCropState() == CropState.HARVESTABLE)
+					else if (prediction.getCropState() == CropState.HARVESTABLE || prediction.getCropState() == CropState.DEAD)
 					{
 						PatchImplementation patchImplementation = prediction.getProduce().getPatchImplementation();
 						if (patchImplementation.equals(PatchImplementation.BUSH)
@@ -653,5 +665,11 @@ public class FarmingTracker
 			.append('.');
 
 		notifier.notify(stringBuilder.toString());
+	}
+
+	private boolean shouldSkipFarmingGuildPatch(Tab tab, FarmingPatch patch) {
+		boolean isFarmingGuildEffectedTab = FARMING_GUILD_EFFECTED_TABS.contains(tab);
+		boolean isFarmingGuildPatch = patch.getRegion().getRegionID() == FARMING_GUILD_REGION_ID;
+		return ignoreFarmingGuild && isFarmingGuildEffectedTab && isFarmingGuildPatch;
 	}
 }


### PR DESCRIPTION
Option to ignore the patches in the farming guild as its highly likely that they are offbeat from regular farming runs.

Also a minor fix the "Only Show Harvestable" option. (Dead crops would jam the notification forever.)