### PR TITLE
Anima patch support

### DIFF
--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
@@ -268,7 +268,7 @@ public interface TimeTrackingReminderConfig extends Config {
     @ConfigItem(
             keyName = "animapatch",
             name = "Anima patch",
-            description = "Show an infobox when your anima patch is ready.",
+            description = "Show an infobox when your anima patch is ready to be replaced.",
             section = farmingPatchesSection,
             position = 216
     )

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
@@ -264,4 +264,15 @@ public interface TimeTrackingReminderConfig extends Config {
     default boolean allotmentPatches() {
         return true;
     }
+
+    @ConfigItem(
+            keyName = "animapatch",
+            name = "Anima patch",
+            description = "Show an infobox when your anima patch is ready.",
+            section = farmingPatchesSection,
+            position = 216
+    )
+    default boolean animaPatch() {
+        return true;
+    }
 }

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderInfoBox.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderInfoBox.java
@@ -15,6 +15,8 @@ class TimeTrackingReminderInfoBox extends InfoBox {
     private final BooleanSupplier shouldShowInfoBox;
     @Getter
     private final String shortName;
+    private String overrideMessage;
+    private Color overrideColor;
 
     TimeTrackingReminderInfoBox(
             TimeTrackingReminderPlugin plugin,
@@ -32,6 +34,21 @@ class TimeTrackingReminderInfoBox extends InfoBox {
         this.shouldShowInfoBox = shouldShowInfoBox;
     }
 
+    TimeTrackingReminderInfoBox(
+            TimeTrackingReminderPlugin plugin,
+            TimeTrackingReminderConfig config,
+            String shortName,
+            String tooltip,
+            BufferedImage image,
+            BooleanSupplier shouldShowInfoBox,
+            String overrideMessage,
+            Color overrideColor
+    ) {
+        this(plugin, config, shortName, tooltip, image, shouldShowInfoBox);
+        this.overrideMessage = overrideMessage;
+        this.overrideColor = overrideColor;
+    }
+
     @Override
     public String getName() {
         String id = tooltip.toLowerCase().replaceAll("\\W+", "_");
@@ -40,12 +57,12 @@ class TimeTrackingReminderInfoBox extends InfoBox {
 
     @Override
     public String getText() {
-        return config.customMessage();
+        return overrideMessage != null ? overrideMessage : config.customMessage();
     }
 
     @Override
     public Color getTextColor() {
-        return Color.GREEN;
+        return overrideColor != null ? overrideColor : Color.GREEN;
     }
 
     @Override

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
@@ -22,6 +22,8 @@ import net.runelite.client.plugins.timetracking.SummaryState;
 import net.runelite.client.plugins.timetracking.TimeTrackingConfig;
 import net.runelite.client.ui.overlay.infobox.InfoBoxManager;
 
+import java.awt.*;
+
 @Slf4j
 @PluginDescriptor(
         name = "Time Tracking Reminder",
@@ -261,7 +263,9 @@ public class TimeTrackingReminderPlugin extends Plugin {
                         "Anima patch",
                         "Your anima patch is ready for replacement.",
                         itemManager.getImage(ItemID.ANIMAINFUSED_BARK),
-                        () -> config.animaPatch() && farmingTracker.getSummary(Tab.ANIMA) != SummaryState.IN_PROGRESS
+                        () -> config.animaPatch() && farmingTracker.getSummary(Tab.ANIMA) != SummaryState.IN_PROGRESS,
+                        "Dead",
+                        Color.RED
                 ),
                 new TimeTrackingReminderInfoBox(
                         this,

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
@@ -258,12 +258,20 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 new TimeTrackingReminderInfoBox(
                         this,
                         config,
+                        "Anima patch",
+                        "Your anima patch is ready.",
+                        itemManager.getImage(ItemID.ANIMAINFUSED_BARK),
+                        () -> config.animaPatch() && (config.onlyHarvestable() ? farmingTracker.getHarvestable(Tab.ANIMA) : farmingTracker.getSummary(Tab.ANIMA) != SummaryState.IN_PROGRESS)
+                ),
+                new TimeTrackingReminderInfoBox(
+                        this,
+                        config,
                         "Crystal patch",
                         "Your Crystal patch is ready.",
                         itemManager.getImage(ItemID.CRYSTAL_SHARD),
                         () -> config.crystalPatch() && (config.onlyHarvestable() ?
                                 farmingTracker.getHarvestable(Tab.CRYSTAL) :
-                                (farmingTracker.getSummary(Tab.CRYSTAL) != SummaryState.IN_PROGRESS && 
+                                (farmingTracker.getSummary(Tab.CRYSTAL) != SummaryState.IN_PROGRESS &&
                                         farmingTracker.getSummary(Tab.CRYSTAL) != SummaryState.EMPTY)
                         )
                 )

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
@@ -259,9 +259,9 @@ public class TimeTrackingReminderPlugin extends Plugin {
                         this,
                         config,
                         "Anima patch",
-                        "Your anima patch is ready.",
+                        "Your anima patch is ready for replacement.",
                         itemManager.getImage(ItemID.ANIMAINFUSED_BARK),
-                        () -> config.animaPatch() && (config.onlyHarvestable() ? farmingTracker.getHarvestable(Tab.ANIMA) : farmingTracker.getSummary(Tab.ANIMA) != SummaryState.IN_PROGRESS)
+                        () -> config.animaPatch() && farmingTracker.getSummary(Tab.ANIMA) != SummaryState.IN_PROGRESS
                 ),
                 new TimeTrackingReminderInfoBox(
                         this,

--- a/src/main/java/com/timetrackingreminder/runelite/farming/FarmingTracker.java
+++ b/src/main/java/com/timetrackingreminder/runelite/farming/FarmingTracker.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashSet;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import lombok.AccessLevel;
@@ -81,6 +82,8 @@ public class FarmingTracker
 	 */
 	private final Map<Tab, Long> completionTimes = new EnumMap<>(Tab.class);
 	Map<ProfilePatch, Boolean> wasNotified = new HashMap<>();
+
+	private Map<Tab, Set<FarmingPatch>> customizedTabData = null;
 
 	private boolean newRegionLoaded;
 	private Collection<FarmingRegion> lastRegions;
@@ -432,7 +435,7 @@ public class FarmingTracker
 	 */
 	public void updateCompletionTime()
 	{
-		for (Map.Entry<Tab, Set<FarmingPatch>> tab : farmingWorld.getTabs().entrySet())
+		for (Map.Entry<Tab, Set<FarmingPatch>> tab : getTabData())
 		{
 			long extremumCompletionTime = config.preferSoonest() ? Long.MAX_VALUE : 0;
 			boolean allUnknown = true;
@@ -536,7 +539,7 @@ public class FarmingTracker
 			Integer offsetPrecisionMins = configManager.getConfiguration(TimeTrackingConfig.CONFIG_GROUP, profile.getKey(), TimeTrackingConfig.FARM_TICK_OFFSET_PRECISION, int.class);
 			Integer offsetTimeMins = configManager.getConfiguration(TimeTrackingConfig.CONFIG_GROUP, profile.getKey(), TimeTrackingConfig.FARM_TICK_OFFSET, int.class);
 
-			for (Map.Entry<Tab, Set<FarmingPatch>> tab : farmingWorld.getTabs().entrySet())
+			for (Map.Entry<Tab, Set<FarmingPatch>> tab : getTabData())
 			{
 				for (FarmingPatch patch : tab.getValue())
 				{
@@ -570,6 +573,39 @@ public class FarmingTracker
 			}
 		}
 		firstNotifyCheck = false;
+	}
+
+	private Set<Map.Entry<Tab, Set<FarmingPatch>>> getTabData() {
+		if (customizedTabData == null) {
+			customizedTabData = buildCustomTabData();
+		}
+		return customizedTabData.entrySet();
+	}
+
+	// Build or own copy of FarmingWorld's Tab->FarmingPatch map to allow customizations
+	private Map<Tab, Set<FarmingPatch>> buildCustomTabData() {
+		Map<Tab, Set<FarmingPatch>> customTabData = new HashMap<>();
+
+		Map<Tab, Set<FarmingPatch>> vanillaTabData = farmingWorld.getTabs();
+		for (Tab defaultTab : vanillaTabData.keySet()) {
+			for (FarmingPatch patch : vanillaTabData.get(defaultTab)) {
+				Tab tab = determineTabForPatch(patch, defaultTab);
+				{
+					Set<FarmingPatch> values = customTabData.getOrDefault(tab, new HashSet<>());
+					values.add(patch);
+					customTabData.put(tab, values);
+				}
+			}
+		}
+
+		return customTabData;
+	}
+
+	private Tab determineTabForPatch(FarmingPatch patch, Tab defaultTab) {
+		if (patch.getImplementation() == PatchImplementation.ANIMA) {
+			return Tab.ANIMA;
+		}
+		return defaultTab;
 	}
 
 	@VisibleForTesting

--- a/src/main/java/com/timetrackingreminder/runelite/farming/FarmingTracker.java
+++ b/src/main/java/com/timetrackingreminder/runelite/farming/FarmingTracker.java
@@ -582,7 +582,7 @@ public class FarmingTracker
 		return customizedTabData.entrySet();
 	}
 
-	// Build or own copy of FarmingWorld's Tab->FarmingPatch map to allow customizations
+	// Build our own copy of FarmingWorld's Tab->FarmingPatch map to allow customizations
 	private Map<Tab, Set<FarmingPatch>> buildCustomTabData() {
 		Map<Tab, Set<FarmingPatch>> customTabData = new HashMap<>();
 

--- a/src/main/java/com/timetrackingreminder/runelite/farming/Tab.java
+++ b/src/main/java/com/timetrackingreminder/runelite/farming/Tab.java
@@ -29,7 +29,11 @@ public enum Tab {
     CACTUS("Cactus Patches", ItemID.POTATO_CACTUS),
     HESPORI("Hespori Patch", ItemID.TANGLEROOT),
     CRYSTAL("Crystal Patch", ItemID.CRYSTAL_SHARD),
-    TIME_OFFSET("Farming Tick Offset", ItemID.WATERING_CAN);
+    TIME_OFFSET("Farming Tick Offset", ItemID.WATERING_CAN),
+
+    // Custom Tabs
+    ANIMA("Anima Patch", ItemID.ANIMAINFUSED_BARK)
+    ;
 
     public static final Tab[] FARMING_TABS = {HERB, TREE, FRUIT_TREE, SPECIAL, FLOWER, ALLOTMENT, BUSH, GRAPE, HOPS, CRYSTAL};
 


### PR DESCRIPTION
Support for showing an infobox for the anima patch.

Let me know if you want me to take a different approach to isolating the patch.
The plugin is coupled pretty tightly to Time Tracking's tabs, so spoofing a tab seemed the path of least resistance.

Resolves #42 