### PR TITLE
Fix Celastrus Tree Contracts

### DIFF
--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
@@ -223,7 +223,7 @@ public class TimeTrackingReminderPlugin extends Plugin {
                         config,
                         "celastrus patch",
                         "Your celastrus patch is ready.",
-                        itemManager.getImage(ItemID.CELASTRUS_BARK),
+                        itemManager.getImage(ItemID.BATTLESTAFF),
                         () -> config.celastrusPatch() && (config.onlyHarvestable() ? farmingTracker.getHarvestable(Tab.CELASTRUS) : farmingTracker.getSummary(Tab.CELASTRUS) != SummaryState.IN_PROGRESS)
                 ),
                 new TimeTrackingReminderInfoBox(

--- a/src/main/java/com/timetrackingreminder/runelite/farming/Produce.java
+++ b/src/main/java/com/timetrackingreminder/runelite/farming/Produce.java
@@ -130,7 +130,7 @@ public enum Produce
 	BELLADONNA("Belladonna", PatchImplementation.BELLADONNA, ItemID.CAVE_NIGHTSHADE, 80, 5),
 	CALQUAT("Calquat", PatchImplementation.CALQUAT, ItemID.CALQUAT_FRUIT, 160, 9, 0, 7),
 	SPIRIT_TREE("Spirit tree", PatchImplementation.SPIRIT_TREE, ItemID.SPIRIT_TREE, 320, 13),
-	CELASTRUS("Celastrus", "Celastrus tree", PatchImplementation.CELASTRUS, ItemID.CELASTRUS_BARK, 160, 6, 0, 4),
+	CELASTRUS("Celastrus", "Celastrus tree", PatchImplementation.CELASTRUS, ItemID.BATTLESTAFF, 160, 6, 0, 4),
 	REDWOOD("Redwood", "Redwood tree", PatchImplementation.REDWOOD, ItemID.REDWOOD_LOGS, 640, 11),
 	HESPORI("Hespori", PatchImplementation.HESPORI, NullItemID.NULL_23044, 640, 4, 0, 2),
 	CRYSTAL_TREE("Crystal tree", PatchImplementation.CRYSTAL_TREE, ItemID.CRYSTAL_SHARDS, 80, 7),

--- a/src/main/java/com/timetrackingreminder/runelite/farming/Tab.java
+++ b/src/main/java/com/timetrackingreminder/runelite/farming/Tab.java
@@ -24,7 +24,7 @@ public enum Tab {
     BIG_COMPOST("Giant Compost Bin", ItemID.ULTRACOMPOST),
     SEAWEED("Seaweed Patches", ItemID.GIANT_SEAWEED),
     CALQUAT("Calquat Patch", ItemID.CALQUAT_FRUIT),
-    CELASTRUS("Celastrus Patch", ItemID.CELASTRUS_BARK),
+    CELASTRUS("Celastrus Patch", ItemID.BATTLESTAFF),
     HARDWOOD("Hardwood Patches", ItemID.TEAK_LOGS),
     REDWOOD("Redwood Patch", ItemID.REDWOOD_LOGS),
     CACTUS("Cactus Patches", ItemID.POTATO_CACTUS),


### PR DESCRIPTION
Base Runelite has produce of Celastrus trees listed as Battlestaves, not celastrus bark. 
Syncing to fix celastrus farming contracts.