### PR TITLE
Add support for grape patches

### DIFF
--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderConfig.java
@@ -318,4 +318,13 @@ public interface TimeTrackingReminderConfig extends Config {
             position = 217
     )
     default boolean coralPatches() { return true; }
+
+    @ConfigItem(
+            keyName = "grapepatches",
+            name = "Grape patches",
+            description = "Show an infobox when your grape patches are ready.",
+            section = farmingPatchesSection,
+            position = 218
+    )
+    default boolean grapePatches() { return true; }
 }

--- a/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
+++ b/src/main/java/com/timetrackingreminder/TimeTrackingReminderPlugin.java
@@ -175,6 +175,14 @@ public class TimeTrackingReminderPlugin extends Plugin {
                 new TimeTrackingReminderInfoBox(
                         this,
                         config,
+                        "grape patches",
+                        "Your grape patches are ready.",
+                        itemManager.getImage(ItemID.GRAPES),
+                        () -> config.grapePatches() && (config.onlyHarvestable() ? farmingTracker.getHarvestable(Tab.GRAPE) : farmingTracker.getSummary(Tab.GRAPE) != SummaryState.IN_PROGRESS)
+                ),
+                new TimeTrackingReminderInfoBox(
+                        this,
+                        config,
                         "seaweed patches",
                         "Your seaweed patches are ready.",
                         itemManager.getImage(ItemID.GIANT_SEAWEED),


### PR DESCRIPTION
Implements support for the grape patches at the Hosidius vinery!

This is my first time contributing to a Runelite plugin, please let me know if anything looks incorrect. These changes seemed to build and test just fine.